### PR TITLE
Fix for deprecated util.print and util.puts (Node.js 0.11.x)

### DIFF
--- a/lib/levelbase.js
+++ b/lib/levelbase.js
@@ -65,7 +65,7 @@ LevelBase.prototype.echo = function (message, options) {
 
   // output a message without any colors
   if (this.noColor) {
-      console.log(message + nl);
+      process.stdout.write(message + nl);
     return this;
   }
 
@@ -94,7 +94,7 @@ LevelBase.prototype.echo = function (message, options) {
   }
 
   // output the message
-  console.log(coloredOutput(message + nl));
+  process.stdout.write(coloredOutput(message + nl));
   return this;
 };
 


### PR DESCRIPTION
Tested on Win and Linux with Node 0.11.10
