### PR TITLE
Bump cli-color to 1.1.0 and make sure to clear formatting on rest of line

### DIFF
--- a/lib/levelbase.js
+++ b/lib/levelbase.js
@@ -95,6 +95,10 @@ LevelBase.prototype.echo = function (message, options) {
 
   // output the message
   process.stdout.write(coloredOutput(message + nl));
+
+  // force-clear formatting on rest of line / new line
+  process.stdout.write(clc.erase.lineRight);
+
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "cli-color": "0.3.2"
+    "cli-color": "1.1.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
The test summary line is output with a background color. On Fedora Linux with
the standard Gnome terminal, the background color is erroneously carried over
to the next line (which has the command prompt).

This commit clears the formatting on the rest of the line after outputting.
For this purpose, the cli-color dependency had to be updated to the most
recent version.
